### PR TITLE
Initialize Chirp multi module project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Swift Package build artifacts
+.build/

--- a/AcousticTempKit/Package.swift
+++ b/AcousticTempKit/Package.swift
@@ -1,0 +1,25 @@
+// swift-tools-version: 5.9
+import PackageDescription
+
+let package = Package(
+    name: "AcousticTempKit",
+    platforms: [
+        .iOS(.v17)
+    ],
+    products: [
+        .library(
+            name: "AcousticTempKit",
+            targets: ["AcousticTempKit"])
+    ],
+    targets: [
+        .target(
+            name: "AcousticTempKit",
+            path: "Sources/AcousticTempKit"
+        ),
+        .testTarget(
+            name: "AcousticTempKitTests",
+            dependencies: ["AcousticTempKit"],
+            path: "Tests/AcousticTempKitTests"
+        )
+    ]
+)

--- a/AcousticTempKit/Sources/AcousticTempKit/AcousticTempKit.swift
+++ b/AcousticTempKit/Sources/AcousticTempKit/AcousticTempKit.swift
@@ -1,0 +1,7 @@
+public enum TempError: Error {
+    case unknown
+}
+
+public struct AcousticTempKit {
+    public init() {}
+}

--- a/AcousticTempKit/Tests/AcousticTempKitTests/AcousticTempKitTests.swift
+++ b/AcousticTempKit/Tests/AcousticTempKitTests/AcousticTempKitTests.swift
@@ -1,0 +1,8 @@
+import XCTest
+@testable import AcousticTempKit
+
+final class AcousticTempKitTests: XCTestCase {
+    func testExample() throws {
+        _ = AcousticTempKit()
+    }
+}

--- a/ChirpApp/ChirpApp.xcodeproj/project.pbxproj
+++ b/ChirpApp/ChirpApp.xcodeproj/project.pbxproj
@@ -1,0 +1,190 @@
+// !$*UTF8*$!
+{
+    archiveVersion = 1;
+    classes = {};
+    objectVersion = 56;
+    objects = {
+
+/* Begin PBXBuildFile section */
+        E7E2D6EE895CAECC00E1A845 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7E2D6EE895CAECC00E1A845; };
+        E7E2D6EF895CAECC00E1A845 /* ChirpAppApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7E2D6EF895CAECC00E1A845; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+        E7E2D6EE895CAECC00E1A845 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
+        E7E2D6EF895CAECC00E1A845 /* ChirpAppApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChirpAppApp.swift; sourceTree = "<group>"; };
+        E7E2D6EA895CAECC00E1A845 /* ChirpApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; path = ChirpApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
+        E7E2D6F0895CAECC00E1A845 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+        E7E2D6E9895CAECC00E1A845 /* Frameworks */ = {
+            isa = PBXFrameworksBuildPhase;
+            buildActionMask = 2147483647;
+            files = (
+            );
+            runOnlyForDeploymentPostprocessing = 0;
+        };
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+        E7E2D6EC895CAECC00E1A845 = {
+            isa = PBXGroup;
+            children = (
+                E7E2D6EB895CAECC00E1A845 /* ChirpApp */,
+                E7E2D6ED895CAECC00E1A845 /* Products */,
+            );
+            sourceTree = "<group>";
+        };
+        E7E2D6EB895CAECC00E1A845 /* ChirpApp */ = {
+            isa = PBXGroup;
+            children = (
+                E7E2D6EE895CAECC00E1A845 /* ContentView.swift */,
+                E7E2D6EF895CAECC00E1A845 /* ChirpAppApp.swift */,
+                E7E2D6F0895CAECC00E1A845 /* Info.plist */,
+            );
+            path = "";
+            sourceTree = "<group>";
+        };
+        E7E2D6ED895CAECC00E1A845 /* Products */ = {
+            isa = PBXGroup;
+            children = (
+                E7E2D6EA895CAECC00E1A845 /* ChirpApp.app */,
+            );
+            path = "";
+            sourceTree = "<group>";
+        };
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+        E7E2D6E3895CAECC00E1A845 /* ChirpApp */ = {
+            isa = PBXNativeTarget;
+            buildConfigurationList = E7E2D6E4895CAECC00E1A845;
+            buildPhases = (
+                E7E2D6E7895CAECC00E1A845 /* Sources */,
+                E7E2D6E8895CAECC00E1A845 /* Resources */,
+                E7E2D6E9895CAECC00E1A845 /* Frameworks */,
+            );
+            buildRules = (
+            );
+            dependencies = (
+            );
+            name = ChirpApp;
+            productName = ChirpApp;
+            productReference = E7E2D6EA895CAECC00E1A845 /* ChirpApp.app */;
+            productType = "com.apple.product-type.application";
+        };
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+        E7E2D6DF895CAECC00E1A845 /* Project object */ = {
+            isa = PBXProject;
+            attributes = {
+                LastSwiftUpdateCheck = 9999;
+                LastUpgradeCheck = 1600;
+            };
+            buildConfigurationList = E7E2D6E0895CAECC00E1A845;
+            compatibilityVersion = "Xcode 16.0";
+            developmentRegion = en;
+            hasScannedForEncodings = 0;
+            mainGroup = E7E2D6EC895CAECC00E1A845;
+            productRefGroup = E7E2D6ED895CAECC00E1A845 /* Products */;
+            projectDirPath = "";
+            projectRoot = "";
+            targets = (
+                E7E2D6E3895CAECC00E1A845 /* ChirpApp */,
+            );
+        };
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+        E7E2D6E8895CAECC00E1A845 /* Resources */ = {
+            isa = PBXResourcesBuildPhase;
+            buildActionMask = 2147483647;
+            files = (
+            );
+            runOnlyForDeploymentPostprocessing = 0;
+        };
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+        E7E2D6E7895CAECC00E1A845 /* Sources */ = {
+            isa = PBXSourcesBuildPhase;
+            buildActionMask = 2147483647;
+            files = (
+                E7E2D6EE895CAECC00E1A845 /* ContentView.swift in Sources */,
+                E7E2D6EF895CAECC00E1A845 /* ChirpAppApp.swift in Sources */,
+            );
+            runOnlyForDeploymentPostprocessing = 0;
+        };
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+        E7E2D6E1895CAECC00E1A845 /* Debug */ = {
+            isa = XCBuildConfiguration;
+            buildSettings = {
+                PRODUCT_NAME = "$(TARGET_NAME)";
+                SWIFT_VERSION = 5.9;
+                TARGETED_DEVICE_FAMILY = "1";
+            };
+            name = Debug;
+        };
+        E7E2D6E2895CAECC00E1A845 /* Release */ = {
+            isa = XCBuildConfiguration;
+            buildSettings = {
+                PRODUCT_NAME = "$(TARGET_NAME)";
+                SWIFT_VERSION = 5.9;
+                TARGETED_DEVICE_FAMILY = "1";
+            };
+            name = Release;
+        };
+        E7E2D6E5895CAECC00E1A845 /* Debug */ = {
+            isa = XCBuildConfiguration;
+            buildSettings = {
+                INFOPLIST_FILE = Info.plist;
+                PRODUCT_BUNDLE_IDENTIFIER = com.example.ChirpApp;
+                PRODUCT_NAME = "$(TARGET_NAME)";
+                SWIFT_VERSION = 5.9;
+                IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+                TARGETED_DEVICE_FAMILY = "1";
+            };
+            name = Debug;
+        };
+        E7E2D6E6895CAECC00E1A845 /* Release */ = {
+            isa = XCBuildConfiguration;
+            buildSettings = {
+                INFOPLIST_FILE = Info.plist;
+                PRODUCT_BUNDLE_IDENTIFIER = com.example.ChirpApp;
+                PRODUCT_NAME = "$(TARGET_NAME)";
+                SWIFT_VERSION = 5.9;
+                IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+                TARGETED_DEVICE_FAMILY = "1";
+            };
+            name = Release;
+        };
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+        E7E2D6E0895CAECC00E1A845 /* Build configuration list for PBXProject "ChirpApp" */ = {
+            isa = XCConfigurationList;
+            buildConfigurations = (
+                E7E2D6E1895CAECC00E1A845 /* Debug */,
+                E7E2D6E2895CAECC00E1A845 /* Release */,
+            );
+            defaultConfigurationIsVisible = 0;
+            defaultConfigurationName = Release;
+        };
+        E7E2D6E4895CAECC00E1A845 /* Build configuration list for PBXNativeTarget "ChirpApp" */ = {
+            isa = XCConfigurationList;
+            buildConfigurations = (
+                E7E2D6E5895CAECC00E1A845 /* Debug */,
+                E7E2D6E6895CAECC00E1A845 /* Release */,
+            );
+            defaultConfigurationIsVisible = 0;
+            defaultConfigurationName = Release;
+        };
+/* End XCConfigurationList section */
+
+    };
+    rootObject = E7E2D6DF895CAECC00E1A845 /* Project object */;
+}

--- a/ChirpApp/ChirpAppApp.swift
+++ b/ChirpApp/ChirpAppApp.swift
@@ -1,0 +1,10 @@
+import SwiftUI
+
+@main
+struct ChirpAppApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}

--- a/ChirpApp/ContentView.swift
+++ b/ChirpApp/ContentView.swift
@@ -1,0 +1,11 @@
+import SwiftUI
+
+struct ContentView: View {
+    var body: some View {
+        Text("Hello, world!")
+    }
+}
+
+#Preview {
+    ContentView()
+}

--- a/ChirpApp/Info.plist
+++ b/ChirpApp/Info.plist
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleIdentifier</key>
+    <string>com.example.ChirpApp</string>
+    <key>CFBundleName</key>
+    <string>ChirpApp</string>
+    <key>CFBundlePackageType</key>
+    <string>APPL</string>
+    <key>UILaunchStoryboardName</key>
+    <string></string>
+    <key>UIApplicationSceneManifest</key>
+    <dict>
+        <key>UIApplicationSupportsMultipleScenes</key>
+        <false/>
+    </dict>
+</dict>
+</plist>


### PR DESCRIPTION
## Summary
- set up `AcousticTempKit` Swift package with a simple error enum
- add unit tests for `AcousticTempKit`
- create `ChirpApp` iOS application Xcode project skeleton for iOS 17
- provide basic SwiftUI app and content view
- include Info.plist and gitignore

## Testing
- `swift test --enable-code-coverage` in `AcousticTempKit`
- `swift test --package-path AcousticTempKit --enable-code-coverage`

------
https://chatgpt.com/codex/tasks/task_e_685ec81ca8b8832c9d7e152b8683ff40